### PR TITLE
Shorten url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ window.onhashchange = () => {
 };
 
 // Parse the parameters from the URL hash.
-dataFlow('paramsIn', parseParams, 'urlIn');
+dataFlow('paramsIn', parseParams, 'urlIn, availableTypes');
 
 // The selected population types.
 // Initialized to the parameters from the URL hash.
@@ -162,14 +162,8 @@ dataFlow('typeSelector', (types, availableTypes) => {
   });
 }, 'types, availableTypes');
 
-// Set up routing to synchronize URL hash parameters with dataflow.
-
-
-// This property is set when parameter properties update
-dataFlow('paramsOut', (src, dest, types) => ({
-  src, dest, types
-}), 'src, dest, types');
-
-dataFlow('urlOut', paramsOut => {
-  location.hash = encodeParams(paramsOut);
-}, 'paramsOut');
+// Update the URL when properties change.
+dataFlow('urlOut', (src, dest, types, availableTypes) => {
+  const params = { src, dest, types };
+  location.hash = encodeParams(params, availableTypes);
+}, 'src, dest, types, availableTypes');

--- a/src/router.js
+++ b/src/router.js
@@ -1,18 +1,30 @@
 import queryString from 'query-string';
 
-export function parseParams(hash) {
+function parseTypes(types, availableTypes) {
+  return types
+    .split('-')
+    .map(i => availableTypes[i]);
+}
+
+function encodeTypes(types, availableTypes) {
+  return types
+    .map(type => availableTypes.indexOf(type))
+    .join('-');
+}
+
+export function parseParams(hash, availableTypes) {
   const params = queryString.parse(hash);
   return {
     src: params.src || null,
     dest: params.dest || null,
-    types: params.types ? JSON.parse(params.types) : null
+    types: params.types ? parseTypes(params.types, availableTypes) : null
   };
 }
 
-export function encodeParams(params) {
+export function encodeParams(params, availableTypes) {
   return queryString.stringify({
     src: params.src,
     dest: params.dest,
-    types: JSON.stringify(params.types)
+    types: encodeTypes(params.types, availableTypes)
   });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,14 +5,14 @@ module.exports = [
     entry: './src/index.js',
     output: {
       filename: 'dist/bundle.js',
-      path: path.resolve(__dirname, 'dist')
+      path: __dirname
     }
   },
   {
     entry: './src/apiSimulationWorker.js',
     output: {
       filename: 'dist/apiSimulationWorker.js',
-      path: path.resolve(__dirname, 'dist')
+      path: __dirname
     }
   }
 ];


### PR DESCRIPTION
With this change, the selected population types are represented in the URL hash as numbers (indices in the array of available types), joined by dashes, like this: 
[http://localhost:8080/#dest&src=Ethiopia&types=0-4-5-6-3](http://localhost:8080/#dest&src=Ethiopia&types=0-4-5-6-3).

![image](https://user-images.githubusercontent.com/68416/30482956-b487f602-9a42-11e7-88e6-25db72699b2b.png)
