### PR TITLE
Debounce labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1806,6 +1806,11 @@
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+    },
     "loglevel": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.1.0",
     "d3-shape": "^1.2.0",
+    "lodash.debounce": "^4.0.8",
     "query-string": "^5.0.0",
     "reactive-model": "^0.13.0"
   },

--- a/src/router.js
+++ b/src/router.js
@@ -1,30 +1,44 @@
 import queryString from 'query-string';
 
-function parseTypes(types, availableTypes) {
-  return types
-    .split('-')
-    .map(i => availableTypes[i - 1]);
-}
+// Parses the types from the URL "types" parameter,
+// which is encoded as, for example "1-3-4-5".
+const parseTypes = (types, availableTypes) => types
+  .split('-')
+  .map(i => availableTypes[i - 1]);
 
-function encodeTypes(types, availableTypes) {
-  return types
-    .map(type => availableTypes.indexOf(type) + 1)
-    .join('-');
-}
+// Encodes the list of selected types into the string
+// that will go in the URL "types" parameter.
+const encodeTypes = (types, availableTypes) => types
+  .map(type => availableTypes.indexOf(type) + 1)
+  .join('-');
 
+// Parses the "src" and "dest" parameter values.
+// If the value is undefined, return "null",
+// so the value will be considered as defined
+// in the data flow graph (null means no selection).
+const parsePlace = place => place || null;
+
+// Encodes the "src" and "dest" parameter values
+// for use in the URL. The value "undefined" is used
+// so that if no src is selected, the src parameter
+// is omitted from the URL (null causes "src" to show up).
+const encodePlace = place => place || undefined;
+
+// Parses the parameters from the URL hash.
 export function parseParams(hash, availableTypes) {
   const params = queryString.parse(hash);
   return {
-    src: params.src || null,
-    dest: params.dest || null,
+    src: parsePlace(params.src),
+    dest: parsePlace(params.dest),
     types: params.types ? parseTypes(params.types, availableTypes) : null
   };
 }
 
+// Encodes the parameters into the URL hash.
 export function encodeParams(params, availableTypes) {
   return queryString.stringify({
-    src: params.src,
-    dest: params.dest,
+    src: encodePlace(params.src),
+    dest: encodePlace(params.dest),
     types: encodeTypes(params.types, availableTypes)
   });
 }


### PR DESCRIPTION
Closes #48 

After this change, the label appearance will be debounced by half a second. This means that, for example, you can resize the window and the stream areas will update immediately, but only after you stop resizing the window will the labels appear. This improves perceived performance when resizing and selecting population types.