### PR TITLE
Set year when hovering over areas

### DIFF
--- a/src/streamGraph.js
+++ b/src/streamGraph.js
@@ -152,7 +152,8 @@ const StreamGraph = component('g')
             // pass null to the click callback to signal de-selection.
             onStreamClick(null);
           }
-        });
+        })
+        .on('mousemove', invokeWithYear(onYearSelect, selection, xScale));
     paths.exit().remove();
 
     // Render the labels.


### PR DESCRIPTION
After this change, the selected year changes as you hover over the StreamGraph areas.

Closes #69