### PR TITLE
Make axis text size depend on width

### DIFF
--- a/src/timePanel.js
+++ b/src/timePanel.js
@@ -24,7 +24,7 @@ const timePanel = component('g')
     selection.selectAll('.tick text')
         .attr('dy', '0.32em')
         .attr('y', box.y + box.height / 2)
-        .style('font-size', '16pt')
+        .style('font-size', `${box.width / 70}pt`)
         .style('font-family', 'Lato,Arial,Helvetica,sans-serif')
         .style('fill', '#030303')
         .style('pointer-events', 'none');


### PR DESCRIPTION
Closes #89

This only affects the tick text. Let's discuss which other text should get smaller.

Wide:
![image](https://user-images.githubusercontent.com/68416/33124536-55302fa8-cfa3-11e7-8701-f731bfe369f1.png)

Narrow:

![image](https://user-images.githubusercontent.com/68416/33124557-6ccb8914-cfa3-11e7-8ed1-01021fa2019a.png)
